### PR TITLE
Fix realtimedb, MeetingRequests

### DIFF
--- a/iOS_Project/LocationManagers/AppLocationCoordinator.swift
+++ b/iOS_Project/LocationManagers/AppLocationCoordinator.swift
@@ -2,6 +2,7 @@ import CoreLocation
 import FirebaseCore
 import SwiftUI
 import FirebaseDatabase
+import FirebaseFirestore
 import FirebaseAuth
 
 class AppLocationCoordinator: NSObject, ObservableObject, CLLocationManagerDelegate {
@@ -17,11 +18,11 @@ class AppLocationCoordinator: NSObject, ObservableObject, CLLocationManagerDeleg
     
     //lazy var: Firebase가 설정된 후에 데이터베이스를 참조하도록 설정
     private lazy var realtimeDB: DatabaseReference = {
-            guard FirebaseApp.app() != nil else {
-                fatalError("Wait for FirebaseApp to configured")
-            }
-            return Database.database().reference()
-        }()
+        guard FirebaseApp.app() != nil else {
+            fatalError("Wait for FirebaseApp to configured")
+        }
+        return Database.database().reference()
+    }()
     
     private override init() {
         super.init()
@@ -51,7 +52,7 @@ class AppLocationCoordinator: NSObject, ObservableObject, CLLocationManagerDeleg
         locationManager.allowsBackgroundLocationUpdates = true
         locationManager.pausesLocationUpdatesAutomatically = false
         locationManager.startUpdatingLocation()
-
+        
         locationUpdateTimer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
         locationUpdateTimer?.schedule(deadline: .now(), repeating: 10) // 10초마다 실행
         locationUpdateTimer?.setEventHandler { [weak self] in
@@ -120,45 +121,81 @@ class AppLocationCoordinator: NSObject, ObservableObject, CLLocationManagerDeleg
     
     // 모임 등록
     func registerMeeting(_ meeting: MeetingModel) {
-        // 모임 시간 계산
-        let meetingDate = meeting.date
-        let startUploadDate = Calendar.current.date(byAdding: .hour, value: -3, to: meetingDate)!
-        let endUploadDate = Calendar.current.date(byAdding: .hour, value: 1, to: meetingDate)!
+        let currentUID = getCurrentUserID()
+        let db = Firestore.firestore()
         
-        // 현재 시간이 업로드 기간 내에 있는지 확인
-        let currentTime = Date()
-        if currentTime >= startUploadDate && currentTime <= endUploadDate {
-            // 현재 업로드 중인 모임에 추가
-            activeMeetings.append(meeting)
-            print("업로드 활성화된 모임 추가: \(meeting.id)")
+        db.collection("meetings").document(meeting.id).getDocument { [weak self] document, error in
+            guard let self = self else { return }
             
-            // 위치 업데이트 시작 (이미 시작되어 있지 않다면)
-            if authorizationStatus == .authorizedAlways {
-                startUpdatingLocation()
+            if let error = error {
+                print("Firestore에서 모임 문서 조회 실패: \(error.localizedDescription)")
+                return
             }
-        } else if currentTime < startUploadDate {
-            // 업로드 시작 시점에 타이머 설정
-            let delay = startUploadDate.timeIntervalSince(currentTime)
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                self?.activeMeetings.append(meeting)
-                print("타이머 후 업로드 활성화된 모임 추가: \(meeting.id)")
+            
+            guard let document = document, document.exists,
+                  let firestoreMembers = document.data()?["meetingMembers"] as? [String] else {
+                print("모임 문서가 존재하지 않거나 멤버 정보가 없음")
+                return
+            }
+            
+            guard firestoreMembers.contains(currentUID) else {
+                print("Firestore 기준 현재 사용자가 모임 멤버가 아님. 위치 업로드 차단.")
+                return
+            }
+            
+            // 리스너를 통해 모임 삭제 감지
+            db.collection("meetings").document(meeting.id).addSnapshotListener { [weak self] documentSnapshot, error in
+                guard let self = self else { return }
                 
-                if self?.authorizationStatus == .authorizedAlways {
-                    self?.startUpdatingLocation()
+                if let error = error {
+                    print("Firestore 모임 삭제 감지 리스너 에러: \(error)")
+                    return
+                }
+                
+                if documentSnapshot == nil || !documentSnapshot!.exists {
+                    self.activeMeetings.removeAll { $0.id == meeting.id }
+                    print("모임이 Firestore에서 삭제됨. \(meeting.id)")
+                    
+                    if self.activeMeetings.isEmpty {
+                        self.stopUpdatingLocation()
+                    }
                 }
             }
-        }
-        
-        // 업로드 종료 시점에 타이머 설정
-        let endDelay = endUploadDate.timeIntervalSince(currentTime)
-        if endDelay > 0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + endDelay) { [weak self] in
-                self?.activeMeetings.removeAll { $0.id == meeting.id }
-                print("업로드 비활성화된 모임 제거: \(meeting.id)")
-                
-                // 더 이상 활성화된 모임이 없으면 위치 업데이트 중지
-                if self?.activeMeetings.isEmpty == true {
-                    self?.stopUpdatingLocation()
+            
+            let meetingDate = meeting.date
+            let startUploadDate = Calendar.current.date(byAdding: .hour, value: -3, to: meetingDate)!
+            let endUploadDate = Calendar.current.date(byAdding: .hour, value: 1, to: meetingDate)!
+            let currentTime = Date()
+            
+            if currentTime >= startUploadDate && currentTime <= endUploadDate {
+                self.activeMeetings.append(meeting)
+                print("업로드 활성화된 모임 추가: \(meeting.id)")
+                if self.authorizationStatus == .authorizedAlways {
+                    self.startUpdatingLocation()
+                }
+            } else if currentTime < startUploadDate {
+                // 업로드 시작 시점에 타이머 설정
+                let delay = startUploadDate.timeIntervalSince(currentTime)
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    self.activeMeetings.append(meeting)
+                    print("타이머 후 업로드 활성화된 모임 추가: \(meeting.id)")
+                    if self.authorizationStatus == .authorizedAlways {
+                        self.startUpdatingLocation()
+                    }
+                }
+            }
+            
+            // 업로드 종료 시점에 타이머 설정
+            let endDelay = endUploadDate.timeIntervalSince(currentTime)
+            if endDelay > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + endDelay) {
+                    self.activeMeetings.removeAll { $0.id == meeting.id }
+                    print("업로드 비활성화된 모임 제거: \(meeting.id)")
+                    
+                    // 더 이상 활성화된 모임이 없으면 위치 업데이트 중지
+                    if self.activeMeetings.isEmpty {
+                        self.stopUpdatingLocation()
+                    }
                 }
             }
         }
@@ -185,6 +222,6 @@ class AppLocationCoordinator: NSObject, ObservableObject, CLLocationManagerDeleg
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let latestLocation = locations.last else { return }
         currentLocation = latestLocation.coordinate
-
+        
     }
 }


### PR DESCRIPTION
- FireStore의 Meetings 컬렉션과 RealtimeDB의 Meetings를 비교해서, FireStore에는 없는데, RealtimeDB에만 있는 Meeting을 삭제하도록 구현. (10분 단위로 탐색)

- 현재시간 == MeetingDate + 2H 가 되어서 Meeting이 삭제 될 때,  해당 Meeting 에서 보낸 MeetingRequests를 같이 삭제하도록 구현

- MeetingMembers가 1일때 모임 나가기 버튼을 눌렀을 경우 해당 Meeting 에서 보낸 MeetingRequests를 삭제하고 Meeting을 삭제하도록 구현

- 문서 삭제를 위한 FireStore,RealtimeDB 규칙 수정  